### PR TITLE
Refactor parseRepo & add 'get-params' command

### DIFF
--- a/drone/build.go
+++ b/drone/build.go
@@ -86,9 +86,7 @@ func buildCommandFunc(c *cli.Context) {
 
 	// the path is provided as an optional argument that
 	// will otherwise default to $PWD/.drone.yml
-	if len(c.Args()) > 0 {
-		path = c.Args()[0]
-	}
+	path = c.Args().First()
 
 	switch len(path) {
 	case 0:

--- a/drone/delete.go
+++ b/drone/delete.go
@@ -20,11 +20,7 @@ func NewDeleteCommand() cli.Command {
 // deleteCommandFunc executes the "delete" command.
 func deleteCommandFunc(c *cli.Context, client *drone.Client) error {
 	var host, owner, name string
-	var args = c.Args()
-
-	if len(args) != 0 {
-		host, owner, name = parseRepo(args[0])
-	}
+	host, owner, name = parseRepo(c.Args())
 
 	return client.Repos.Delete(host, owner, name)
 }

--- a/drone/disable.go
+++ b/drone/disable.go
@@ -19,12 +19,6 @@ func NewDisableCommand() cli.Command {
 
 // disableCommandFunc executes the "disable" command.
 func disableCommandFunc(c *cli.Context, client *drone.Client) error {
-	var host, owner, name string
-	var args = c.Args()
-
-	if len(args) != 0 {
-		host, owner, name = parseRepo(args[0])
-	}
-
+	host, owner, name := parseRepo(c.Args())
 	return client.Repos.Disable(host, owner, name)
 }

--- a/drone/enable.go
+++ b/drone/enable.go
@@ -19,12 +19,6 @@ func NewEnableCommand() cli.Command {
 
 // enableCommandFunc executes the "enable" command.
 func enableCommandFunc(c *cli.Context, client *drone.Client) error {
-	var host, owner, name string
-	var args = c.Args()
-
-	if len(args) != 0 {
-		host, owner, name = parseRepo(args[0])
-	}
-
+	host, owner, name := parseRepo(c.Args())
 	return client.Repos.Enable(host, owner, name)
 }

--- a/drone/keys.go
+++ b/drone/keys.go
@@ -22,12 +22,9 @@ func NewSetKeyCommand() cli.Command {
 
 // setKeyCommandFunc executes the "set-key" command.
 func setKeyCommandFunc(c *cli.Context, client *drone.Client) error {
-	var host, owner, name, path string
+	var path string
 	var args = c.Args()
-
-	if len(args) != 0 {
-		host, owner, name = parseRepo(args[0])
-	}
+	var host, owner, name = parseRepo(c.Args())
 
 	if len(args) == 2 {
 		path = args[1]

--- a/drone/main.go
+++ b/drone/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"os"
-
 	"errors"
 	"fmt"
-	"github.com/codegangsta/cli"
 	"net/url"
+	"os"
+
+	"github.com/codegangsta/cli"
 )
 
 var (
@@ -46,6 +46,7 @@ func main() {
 		NewSetKeyCommand(),
 		NewDeleteCommand(),
 		NewSetParamsCommand(),
+		NewGetParamsCommand(),
 	}
 
 	app.Before = func(c *cli.Context) error {

--- a/drone/main.go
+++ b/drone/main.go
@@ -46,7 +46,6 @@ func main() {
 		NewSetKeyCommand(),
 		NewDeleteCommand(),
 		NewSetParamsCommand(),
-		NewGetParamsCommand(),
 	}
 
 	app.Before = func(c *cli.Context) error {

--- a/drone/restart.go
+++ b/drone/restart.go
@@ -19,12 +19,9 @@ func NewRestartCommand() cli.Command {
 
 // restartCommandFunc executes the "restart" command.
 func restartCommandFunc(c *cli.Context, client *drone.Client) error {
-	var host, owner, repo, branch, sha string
+	var host, owner, name, branch, sha string
 	var args = c.Args()
-
-	if len(args) != 0 {
-		host, owner, repo = parseRepo(args[0])
-	}
+	host, owner, name = parseRepo(c.Args())
 
 	switch len(args) {
 	case 2:
@@ -35,5 +32,5 @@ func restartCommandFunc(c *cli.Context, client *drone.Client) error {
 		sha = args[2]
 	}
 
-	return client.Commits.Rebuild(host, owner, repo, branch, sha)
+	return client.Commits.Rebuild(host, owner, name, branch, sha)
 }

--- a/drone/setParams.go
+++ b/drone/setParams.go
@@ -12,7 +12,7 @@ import (
 func NewSetParamsCommand() cli.Command {
 	return cli.Command{
 		Name:  "set-params",
-		Usage: "sets params for the repo",
+		Usage: "sets all params for the repo",
 		Flags: []cli.Flag{},
 		Action: func(c *cli.Context) {
 			handle(c, setParamsCommandFunc)
@@ -25,9 +25,7 @@ func setParamsCommandFunc(c *cli.Context, client *drone.Client) error {
 	var host, owner, name, path string
 	var args = c.Args()
 
-	if len(args) != 0 {
-		host, owner, name = parseRepo(args[0])
-	}
+	host, owner, name = parseRepo(c.Args())
 
 	if len(args) == 2 {
 		path = args[1]

--- a/drone/util.go
+++ b/drone/util.go
@@ -2,22 +2,38 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/codegangsta/cli"
 )
 
-func parseRepo(str string) (host, owner, repo string) {
-	var parts = strings.Split(str, "/")
-	if len(parts) != 3 {
-		return
+// parseRepo first attempts to find a repo in the recieved string, if
+func parseRepo(args cli.Args) (host, owner, repo string) {
+	var parts = strings.Split(args.First(), "/")
+	if len(parts) == 3 {
+		return parts[0], parts[1], parts[2]
 	}
-	host = parts[0]
-	owner = parts[1]
-	repo = parts[2]
-	return
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Could not find current repo path: %s", err)
+	}
+
+	gopath, success := getRepoPath(dir)
+	if !success {
+		log.Fatal("Failed to find current repo, please pass a repo as an argument (host/owner/name)")
+	}
+	parts = strings.Split(gopath, "/")
+	if len(parts) < 3 {
+		log.Fatalf("Current repo detected as '%s', failed to discern host, owner & name.", gopath)
+	}
+
+	return parts[0], parts[1], parts[2]
 }
 
 // getGoPath checks the source codes absolute path

--- a/drone/util.go
+++ b/drone/util.go
@@ -14,23 +14,22 @@ import (
 
 // parseRepo first attempts to find a repo in the recieved string, if
 func parseRepo(args cli.Args) (host, owner, repo string) {
-	var parts = strings.Split(args.First(), "/")
-	if len(parts) == 3 {
-		return parts[0], parts[1], parts[2]
-	}
+	var path = args.First()
+	if path == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("Could not find current repo path: %s", err)
+		}
 
-	dir, err := os.Getwd()
-	if err != nil {
-		log.Fatalf("Could not find current repo path: %s", err)
+		var success bool
+		path, success = getRepoPath(dir)
+		if !success {
+			log.Fatal("Failed to find current repo, please pass a repo as an argument (host/owner/name)")
+		}
 	}
-
-	gopath, success := getRepoPath(dir)
-	if !success {
-		log.Fatal("Failed to find current repo, please pass a repo as an argument (host/owner/name)")
-	}
-	parts = strings.Split(gopath, "/")
+	parts := strings.Split(path, "/")
 	if len(parts) < 3 {
-		log.Fatalf("Current repo detected as '%s', failed to discern host, owner & name.", gopath)
+		log.Fatalf("Current repo detected as '%s', failed to discern host, owner & name.", path)
 	}
 
 	return parts[0], parts[1], parts[2]


### PR DESCRIPTION
Currently there's a silent failure when a repo name is not provided. It seems likely that the drone-cli will be used from within the intended repo so this attempts to find that repo if there is not a repo path passed as an argument.

This also reimplements the status command to still work with branches despite the deprecated endpoint.