### PR TITLE
Fix drone exec identity

### DIFF
--- a/drone/exec.go
+++ b/drone/exec.go
@@ -142,6 +142,8 @@ func execCmd(c *cli.Context) error {
 			Repo      drone.Repo      `json:"repo"`
 			Build     drone.Build     `json:"build"`
 			Job       drone.Job       `json:"job"`
+			Netrc     drone.Netrc     `json:"netrc"`
+			Keys      drone.Key       `json:"keys"`
 			Config    string          `json:"config"`
 		}{
 			Repo: drone.Repo{
@@ -169,8 +171,13 @@ func execCmd(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			payload.Workspace.Keys = &drone.Key{
+			payload.Keys = drone.Key{
 				Private: string(key),
+			}
+			payload.Netrc = drone.Netrc{
+				Machine: "",
+				Login: "",
+				Password: "",
 			}
 		}
 


### PR DESCRIPTION
When using `-i` with `drone exec`, the specified key is not applied in the build container, this is caused by the two reasons:

* `docker-exec` [overrides the workspace with its own](https://github.com/drone/drone-exec/blob/master/exec/exec.go#L135), using `payload.Keys` and `payload.Netrc`
* `docker-exec` only adds the key to the build script if both `payload.Workspace.Keys` and `payload.Workspace.Netrc` are present, otherwise it just ignores it ([link](https://github.com/drone/drone-exec/blob/master/runner/script/script.go#L19))

This pull requests fixes this by sending Keys and Netrc where `docker-exec` expects it and by sending an empty Netrc.

For the second issue, it serves just as a temporary fix as this behaviour seems wrong. Also, drone/drone-exec#12 seems to fix this.