### PR TITLE
Pull drone exec image on --pull argument

### DIFF
--- a/drone/exec.go
+++ b/drone/exec.go
@@ -136,6 +136,15 @@ func execCmd(c *cli.Context) error {
 			execArgs = append(execArgs, "--"+arg)
 		}
 	}
+	if c.Bool("pull") {
+		image := "drone/drone-exec:latest"
+		color.Magenta("[DRONE] pulling %s", image)
+		err := cli.PullImage(image, nil)
+		if err != nil {
+			color.Red("[DRONE] failed to pull %s", image)
+			os.Exit(1)
+		}
+	}
 
 	proj := resolvePath(pwd)
 


### PR DESCRIPTION
I expected this to happen because and lost 30-60 minutes figuring out that it wasnt the case.

The --pull usage info just says "always pull the latest docker image" so the solution is to either do  what I've done here or change the usage string.