### PR TITLE
Add --payload argument

### DIFF
--- a/drone/exec.go
+++ b/drone/exec.go
@@ -93,6 +93,10 @@ var ExecCmd = cli.Command{
 			Usage: "hook event type",
 			Value: "push",
 		},
+		cli.StringFlag{
+			Name:  "payload",
+			Usage: "merge the argument's json value with the normal payload",
+		},
 		cli.BoolTFlag{
 			Name:  "debug",
 			Usage: "execute the build in debug mode",
@@ -241,6 +245,19 @@ func execCmd(c *cli.Context) error {
 		if len(proj) != 0 {
 			payload.Repo.Link = fmt.Sprintf("https://%s", proj)
 		}
+		if c.IsSet("payload") {
+			err := json.Unmarshal([]byte(c.String("payload")), &payload)
+			if err != nil {
+				color.Red("Error reading --payload argument, it must be valid json: %v", err)
+				os.Exit(1)
+			}
+		}
+		if c.Bool("debug") {
+			out, _ := json.MarshalIndent(payload, " ", "  ")
+			color.Magenta("[DRONE] job #%d payload:", i+1)
+			fmt.Println(string(out))
+		}
+
 		out, _ := json.Marshal(payload)
 
 		exit, err := run(cli, execArgs, string(out))

--- a/drone/exec.go
+++ b/drone/exec.go
@@ -97,7 +97,7 @@ var ExecCmd = cli.Command{
 			Name:  "payload",
 			Usage: "merge the argument's json value with the normal payload",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "execute the build in debug mode",
 		},


### PR DESCRIPTION
`--dump` just displays the payload as indented json instead of running
  drone-exec.

`--payload` allows merging in a json value as into the generated payload.

Example:

```sh
drone exec  -event tag --payload '{"job":{"id":999}, "build":{"branch":"SOMETHING"}}'  --dump
```

```json
{
   "config": "clone:\n  path: github.com/drone/drone-cli\n\nbuild:\n  image: golang:1.5\n  environment:\n    - GO15VENDOREXPERIMENT=1\n  commands:\n\n    # compile drone for all architectures\n    - GOOS=linux   GOARCH=amd64 go build -o ./bin/linux_amd64/drone   github.com/drone/drone-cli/drone\n    - GOOS=linux   GOARCH=386   go build -o ./bin/linux_386/drone     github.com/drone/drone-cli/drone\n    - GOOS=linux   GOARCH=arm   go build -o ./bin/linux_arm/drone     github.com/drone/drone-cli/drone\n    - GOOS=darwin  GOARCH=amd64 go build -o ./bin/darwin_amd64/drone  github.com/drone/drone-cli/drone\n    - GOOS=windows GOARCH=386   go build -o ./bin/windows_386/drone   github.com/drone/drone-cli/drone\n    - GOOS=windows GOARCH=amd64 go build -o ./bin/windows_amd64/drone github.com/drone/drone-cli/drone\n\n    # tar binary files prior to upload\n    - mkdir dist\n    - tar -cvzf dist/drone_linux_amd64.tar.gz   --directory=bin/linux_amd64   drone\n    - tar -cvzf dist/drone_linux_386.tar.gz     --directory=bin/linux_386     drone\n    - tar -cvzf dist/drone_linux_arm.tar.gz     --directory=bin/linux_arm     drone\n    - tar -cvzf dist/drone_darwin_amd64.tar.gz  --directory=bin/darwin_amd64  drone\n    - tar -cvzf dist/drone_windows_386.tar.gz   --directory=bin/windows_386   drone\n    - tar -cvzf dist/drone_windows_amd64.tar.gz --directory=bin/windows_amd64 drone\n\n    # generate shas for tar files\n    - sha256sum ./dist/drone_linux_amd64.tar.gz   \u003e ./dist/drone_linux_amd64.sha256\n    - sha256sum ./dist/drone_linux_386.tar.gz     \u003e ./dist/drone_linux_386.sha256\n    - sha256sum ./dist/drone_linux_arm.tar.gz     \u003e ./dist/drone_linux_arm.sha256\n    - sha256sum ./dist/drone_darwin_amd64.tar.gz  \u003e ./dist/drone_darwin_amd64.sha256\n    - sha256sum ./dist/drone_windows_386.tar.gz   \u003e ./dist/drone_windows_386.sha256\n    - sha256sum ./dist/drone_windows_amd64.tar.gz \u003e ./dist/drone_windows_amd64.sha256\n\n\npublish:\n  s3:\n    acl: public-read\n    region: us-east-1\n    bucket: downloads.drone.io\n    access_key: $$AWS_KEY\n    secret_key: $$AWS_SECRET\n    source: dist/\n    target: drone-cli/\n    recursive: true\n    when:\n      branch: master\n",
   "secret": "",
   "repo": {
     "id": 0,
     "owner": "",
     "name": "",
     "full_name": "",
     "avatar_url": "",
     "link_url": "https:///github.com/drone/drone-cli",
     "clone_url": "",
     "default_branch": "",
     "timeout": 0,
     "private": true,
     "trusted": false,
     "allow_pr": false,
     "allow_push": false,
     "allow_deploys": false,
     "allow_tags": false
   },
   "build": {
     "id": 0,
     "number": 0,
     "event": "tag",
     "status": "running",
     "enqueued_at": 0,
     "created_at": 0,
     "started_at": 0,
     "finished_at": 0,
     "deploy_to": "",
     "commit": "e90200cf8dade3e162566f6cc16958cb563e4b10",
     "branch": "SOMETHING",
     "ref": "",
     "refspec": "",
     "remote": "",
     "title": "",
     "message": "Add --payload and --dump arguments",
     "timestamp": 0,
     "author": "Thomas Frössman",
     "author_avatar": "",
     "author_email": "thomasf@jossystem.se",
     "link_url": ""
   },
   "build_last": null,
   "job": {
     "id": 999,
     "number": 0,
     "status": "running",
     "exit_code": 0,
     "enqueued_at": 0,
     "started_at": 0,
     "finished_at": 0,
     "environment": {}
   },
   "netrc": null,
   "keys": null,
   "system": {
     "version": "",
     "link_url": "",
     "plugins": [
       "plugins/*",
       "*/*"
     ],
     "globals": [],
     "privileged_plugins": null
   },
   "workspace": null,
   "vargs": null
 }
```

