### PR TITLE
Add globals for exec from plaintext secrets YAML

### DIFF
--- a/drone/helper.go
+++ b/drone/helper.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -41,6 +42,16 @@ func resolvePath(dir string) string {
 	}
 
 	return ""
+}
+
+// readInput reads the plaintext secret from a file
+// or stdin if inFile is -
+func readInput(inFile string) ([]byte, error) {
+	if inFile == "-" {
+		return ioutil.ReadAll(os.Stdin)
+	} else {
+		return ioutil.ReadFile(inFile)
+	}
 }
 
 var gopathExp = regexp.MustCompile("./src/(github.com/[^/]+/[^/]+|bitbucket.org/[^/]+/[^/]+|code.google.com/[^/]+/[^/]+)")

--- a/drone/secure.go
+++ b/drone/secure.go
@@ -149,16 +149,6 @@ func sha256sum(in string) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// readInput reads the plaintext secret from a file
-// or stdin if inFile is -
-func readInput(inFile string) ([]byte, error) {
-	if inFile == "-" {
-		return ioutil.ReadAll(os.Stdin)
-	} else {
-		return ioutil.ReadFile(inFile)
-	}
-}
-
 // writeOutput writes the encrypted secret to a file
 // or stdout if outFile is -
 func writeOutput(outFile string, ciphertext string) error {


### PR DESCRIPTION
Allows `drone exec` to use the plaintext of the secrets YAML to populate environment globals for local builds.