### PR TITLE
Handle error when docker isn't running

### DIFF
--- a/drone/exec.go
+++ b/drone/exec.go
@@ -279,6 +279,9 @@ func run(client dockerclient.Client, args []string, input string) (int, error) {
 	}
 
 	info, err := docker.Run(client, conf, false)
+	if err != nil {
+		return 0, err
+	}
 
 	client.StopContainer(info.Id, 15)
 	client.RemoveContainer(info.Id, true, true)


### PR DESCRIPTION
This prevents drone from crashing if docker isn't running when calling `drone exec`.