### PR TITLE
Convert windows path to something Docker can use

### DIFF
--- a/drone/exec.go
+++ b/drone/exec.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"runtime"
 
 	"gopkg.in/yaml.v2"
 
@@ -159,6 +160,11 @@ func execCmd(c *cli.Context) error {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
+	}
+
+	// Massage windows paths for docker
+	if runtime.GOOS == "windows" {
+		pwd = convertWindowsPath(pwd)
 	}
 
 	execArgs := []string{"--build", "--debug", "--mount", pwd}

--- a/drone/helper.go
+++ b/drone/helper.go
@@ -10,6 +10,19 @@ import (
 	// "time"
 )
 
+func convertWindowsPath(str string) string {
+	// Split path into Array
+	var pwds = strings.Split(str, "\\")
+
+	// Convert drive "C:" to "/c"
+	rp := regexp.MustCompile("(^[a-zA-Z]):")
+	pwds[0] = rp.ReplaceAllString(pwds[0], "/$1")
+	pwds[0] = strings.ToLower(pwds[0])
+
+	// Join path using "/"
+	return strings.Join(pwds, "/")
+}
+
 func parseRepo(str string) (owner, repo string, err error) {
 	var parts = strings.Split(str, "/")
 	if len(parts) != 2 {


### PR DESCRIPTION
Currently on windows I get the following:

```
$ drone exec
[DRONE] starting job #1
[info] Pulling image ruby:latest
[error] Error creating ruby:latest. 500 Internal Server Error: Invalid volume sp
ec "\\Users\\vagrant\\git\\test": volumeabs: Invalid volume destination path: '\
Users\vagrant\git\test' mount path must be absolute.


[info] build failed (exit code 255)
[DRONE] finished job #1
[DRONE] exit code 255
[DRONE] job #1 failed
[DRONE] build failed
```

This PR converts the windows path into a path usable by Docker.