### PR TITLE
Trim slash suffix from the server URL

### DIFF
--- a/drone/handle.go
+++ b/drone/handle.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/drone/drone-go/drone"
@@ -16,7 +17,7 @@ type handlerFunc func(*cli.Context, drone.Client) error
 // sets up the environment.
 func handle(c *cli.Context, fn handlerFunc) {
 	var token = c.GlobalString("token")
-	var server = c.GlobalString("server")
+	var server = strings.TrimSuffix(c.GlobalString("server"), "/")
 
 	// if no server url is provided we can default
 	// to the hosted Drone service.
@@ -24,6 +25,7 @@ func handle(c *cli.Context, fn handlerFunc) {
 		fmt.Println("Error: you must provide the Drone server address.")
 		os.Exit(1)
 	}
+
 	if len(token) == 0 {
 		fmt.Println("Error: you must provide your Drone access token.")
 		os.Exit(1)


### PR DESCRIPTION
Makes https://github.com/drone/docs/pull/123 obsolete