### PR TITLE
Set workspace-base to /drone

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -83,7 +83,7 @@ var Command = cli.Command{
 		//
 		cli.StringFlag{
 			Name:   "workspace-base",
-			Value:  "/pipeline",
+			Value:  "/drone",
 			EnvVar: "DRONE_WORKSPACE_BASE",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
As the drone-agent sets it to /drone as well.
https://github.com/drone/drone/blob/076dc0c3b93b1acde22ee68d4f5506f7d6538efd/server/hook.go#L509