### PR TITLE
pretty logging for drone exec

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -375,7 +375,6 @@ func exec(c *cli.Context) error {
 
 	return pipeline.New(compiled,
 		pipeline.WithContext(ctx),
-		pipeline.WithLogger(defaultLogger),
 		pipeline.WithTracer(pipeline.DefaultTracer),
 		pipeline.WithLogger(defaultLogger),
 		pipeline.WithEngine(engine),
@@ -451,6 +450,9 @@ var defaultLogger = pipeline.LogFunc(func(proc *backend.Step, rc multipart.Reade
 	if err != nil {
 		return err
 	}
-	io.Copy(os.Stderr, part)
+
+	logstream := NewLineWriter(proc.Alias)
+	io.Copy(logstream, part)
+
 	return nil
 })

--- a/drone/exec/line.go
+++ b/drone/exec/line.go
@@ -1,0 +1,67 @@
+package exec
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// Identifies the type of line in the logs.
+const (
+	LineStdout int = iota
+	LineStderr
+	LineExitCode
+	LineMetadata
+	LineProgress
+)
+
+// Line is a line of console output.
+type Line struct {
+	Proc string `json:"proc,omitempty"`
+	Time int64  `json:"time,omitempty"`
+	Type int    `json:"type,omitempty"`
+	Pos  int    `json:"pos,omityempty"`
+	Out  string `json:"out,omitempty"`
+}
+
+// LineWriter sends logs to the client.
+type LineWriter struct {
+	name  string
+	num   int
+	now   time.Time
+	rep   *strings.Replacer
+	lines []*Line
+}
+
+// NewLineWriter returns a new line reader.
+func NewLineWriter(name string) *LineWriter {
+	w := new(LineWriter)
+	w.name = name
+	w.num = 0
+	w.now = time.Now().UTC()
+
+	return w
+}
+
+func (w *LineWriter) Write(p []byte) (n int, err error) {
+	out := string(p)
+	if w.rep != nil {
+		out = w.rep.Replace(out)
+	}
+
+	line := &Line{
+		Out:  out,
+		Proc: w.name,
+		Pos:  w.num,
+		Time: int64(time.Since(w.now).Seconds()),
+		Type: LineStdout,
+	}
+
+	fmt.Fprintf(os.Stderr, "[%s:L%d:%ds] %s", w.name, w.num, int64(time.Since(w.now).Seconds()), out)
+
+	w.num++
+
+	w.lines = append(w.lines, line)
+	return len(p), nil
+}


### PR DESCRIPTION
Basically stole and modified https://github.com/cncd/pipeline/blob/master/pipeline/rpc/line.go#L49 to make `drone exec` pretty again like it was in Drone 0.5

Example `.drone.yml`
```yaml
workspace:
  base: /drone

pipeline:
  first:
    image: ubuntu:16.04
    commands:
      - touch /drone/helloworld
      - sleep 10
      - echo counted?

  second:
    image: ubuntu:16.04
    commands:
      - echo "hello"
      - ls /drone/helloworld
```

Example output with changes:
```
$ ./drone exec
[first:L0:0s] + touch /drone/helloworld
[first:L1:0s] + sleep 10
[first:L2:10s] + echo counted?
[first:L3:10s] counted?
[second:L0:0s] + echo "hello"
[second:L1:0s] hello
[second:L2:0s] + ls /drone/helloworld
[second:L3:0s] ls: cannot access '/drone/helloworld': No such file or directory
2017/06/28 14:23:33 drone_step_1 : exit code 2
```