### PR TITLE
Add mounting drone_default to workspaceBase before mounting git repo

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -327,6 +327,7 @@ func exec(c *cli.Context) error {
 			workspacePath = c.String("workspace-path")
 		}
 		dir, _ := filepath.Abs(filepath.Dir(file))
+		volumes = append(volumes, "drone_default:"+workspaceBase)
 		volumes = append(volumes, dir+":"+path.Join(workspaceBase, workspacePath))
 	}
 

--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -327,7 +327,7 @@ func exec(c *cli.Context) error {
 			workspacePath = c.String("workspace-path")
 		}
 		dir, _ := filepath.Abs(filepath.Dir(file))
-		volumes = append(volumes, "drone_default:"+workspaceBase)
+		volumes = append(volumes, c.String("prefix")+"_default:"+workspaceBase)
 		volumes = append(volumes, dir+":"+path.Join(workspaceBase, workspacePath))
 	}
 


### PR DESCRIPTION
Currently `drone_default` volume is created but not used by `drone exec`.  This adds the persistent workspace base volume.

Example of Issue

`.drone.yml` of
```yml
workspace:
  base: /drone

pipeline:
  first:
    image: ubuntu:16.04
    commands:
      - touch /drone/helloworld
      - echo counted?

  second:
    image: ubuntu:16.04
    commands:
      - echo "hello"
      - ls /drone/helloworld
```

with output of

```
$ drone7 exec
+ touch /drone/helloworld
+ echo counted?
counted?
+ echo "hello"
hello
+ ls /drone/helloworld
ls: cannot access '/drone/helloworld': No such file or directory
2017/06/29 08:12:05 drone_step_1 : exit code 2
```

After fix output of

```
$ ./drone exec
[first:L0:0s] + touch /drone/helloworld
[first:L1:0s] + echo counted?
[first:L2:0s] counted?
[second:L0:0s] + echo "hello"
[second:L1:0s] hello
[second:L2:0s] + ls /drone/helloworld
[second:L3:0s] /drone/helloworld
```

Fixes #47 