### PR TITLE
Enable bash completion

### DIFF
--- a/drone/main.go
+++ b/drone/main.go
@@ -25,6 +25,7 @@ func main() {
 	app.Name = "drone"
 	app.Version = version
 	app.Usage = "command line utility"
+	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "t, token",


### PR DESCRIPTION
Enable Drone CLI to generate bash completion output.  Combined with user copying bash completion script following https://github.com/urfave/cli#distribution this enabled autocomplete with Drone CLI!

Example
```
$ ./drone 
build     exec      help      registry  secret    
deploy    h         info      repo      user
$ ./drone build 
approve  h        info     list     queue    stop     
decline  help     last     logs     start   
```

And yes, it does autocomplete `drone b` -> `drone build` when tabbed and such.  Bit harder to show example of that  😛 

Fixes #40 

https://github.com/urfave/cli#bash-completion

