### PR TITLE
Support providing server and token via ~/.drone.yml file

### DIFF
--- a/drone/main.go
+++ b/drone/main.go
@@ -37,7 +37,7 @@ func getConfig() {
 	// config will be handled on usage.
 	config = Config{}
 	usr, _ := osuser.Current()
-	file, _ := ioutil.ReadFile(usr.HomeDir + "/.dronerc")
+	file, _ := ioutil.ReadFile(usr.HomeDir + "/.drone.yml")
 	yaml.Unmarshal(file, &config)
 }
 

--- a/drone/main.go
+++ b/drone/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"io/ioutil"
+	osuser "os/user"
 
 	"github.com/drone/drone-cli/drone/build"
 	"github.com/drone/drone-cli/drone/deploy"
@@ -15,12 +17,33 @@ import (
 
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/urfave/cli"
+
+	"gopkg.in/yaml.v2"
 )
+
+type Config struct {
+	Server string `yaml:"server"`
+	Token string `yaml:"token"`
+}
 
 // drone version number
 var version string
 
+// configuration
+var config Config
+
+func getConfig() {
+	// Errors are deliberately ignored here as missing/incorrect
+	// config will be handled on usage.
+	config = Config{}
+	usr, _ := osuser.Current()
+	file, _ := ioutil.ReadFile(usr.HomeDir + "/.dronerc")
+	yaml.Unmarshal(file, &config)
+}
+
 func main() {
+	getConfig()
+
 	app := cli.NewApp()
 	app.Name = "drone"
 	app.Version = version
@@ -29,11 +52,13 @@ func main() {
 		cli.StringFlag{
 			Name:   "t, token",
 			Usage:  "server auth token",
+			Value: 	config.Token,
 			EnvVar: "DRONE_TOKEN",
 		},
 		cli.StringFlag{
 			Name:   "s, server",
 			Usage:  "server location",
+			Value: 	config.Server, 
 			EnvVar: "DRONE_SERVER",
 		},
 		cli.BoolFlag{

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -453,8 +453,8 @@
 			"checksumSHA1": "QpWY2ygzClg3Bw+GHjD7yXlcTxw=",
 			"origin": "github.com/cncd/pipeline/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "b0776dfae18d347cbccc8c76874bbbedb7494fdb",
-			"revisionTime": "2017-05-14T17:21:45Z"
+			"revision": "9685a43aa7e8f509e9e3ce14db5e014406d0ab8d",
+			"revisionTime": "2017-06-28T17:01:38Z"
 		}
 	],
 	"rootPath": "github.com/drone/drone-cli"


### PR DESCRIPTION
## Description

* Added ability to specify `~/.drone.yml` file for providing server address and token, rather than supplying as command line arguments or env vars. This provides an alternative option for those who'd rather not provide or export them each time each time, or would rather not have them in their `~/.bashrc` or equivalent. This is similar to tools such as `npm` with `~/.npmrc` or `aws` with `~/.aws/config`.

* An example `~/.drone.yml` file will be as follows:

  ``` yaml
  server = https://drone.mycompany.com/
  token = ey3894n4nndkd84s
  ```

## Documentation

* Happy to update the documentation separately, should this PR be accepted/suitable for the project.