### PR TITLE
Properly get whole value for secrets that contain '='

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -291,7 +291,7 @@ func exec(c *cli.Context) error {
 	}
 	for _, env := range os.Environ() {
 		k := strings.Split(env, "=")[0]
-		v := strings.Split(env, "=")[1]
+		v := strings.SplitN(env, "=", 2)[1]
 		environ[k] = v
 		secrets = append(secrets, compiler.Secret{
 			Name:  k,


### PR DESCRIPTION
Currently a secret set in your env that contains `=` will truncate after first `=` found and everything after.  This PR allows reading in the full secret value.