### PR TITLE
Allow values in key/value pairs to contain '=' characters

### DIFF
--- a/drone/internal/util.go
+++ b/drone/internal/util.go
@@ -87,7 +87,7 @@ func ParseRepo(str string) (user, repo string, err error) {
 func ParseKeyPair(p []string) map[string]string {
 	params := map[string]string{}
 	for _, i := range p {
-		parts := strings.Split(i, "=")
+		parts := strings.SplitN(i, "=", 2)
 		if len(parts) != 2 {
 			continue
 		}

--- a/drone/internal/util_test.go
+++ b/drone/internal/util_test.go
@@ -3,10 +3,13 @@ package internal
 import "testing"
 
 func TestParseKeyPair(t *testing.T) {
-	s := []string{"FOO=bar", "BAR=", "INVALID"}
+	s := []string{"FOO=bar", "BAR=", "BAZ=qux=quux", "INVALID"}
 	p := ParseKeyPair(s)
 	if p["FOO"] != "bar" {
 		t.Errorf("Wanted %q, got %q.", "bar", p["FOO"])
+	}
+	if p["BAZ"] != "qux=quux" {
+		t.Errorf("Wanted %q, got %q.", "qux=quux", p["BAZ"])
 	}
 	if _, exists := p["BAR"]; !exists {
 		t.Error("Missing a key with no value. Keys with empty values are also valid.")


### PR DESCRIPTION
Right now, given a command that takes a param: 
```
drone deploy -p TOKEN=fdslkfsdfs=fdsfs Org/Repo 1 production
```
`TOKEN` does not appear as an environment variable in Drone because its value contains '=' characters.

