### PR TITLE
add in env flag for drone exec 

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -274,6 +274,10 @@ var Command = cli.Command{
 			Name:   "job-number",
 			EnvVar: "DRONE_JOB_NUMBER",
 		},
+		cli.StringSliceFlag{
+			Name: "env, e",
+			EnvVar: "DRONE_ENV",
+		},
 	},
 }
 
@@ -295,6 +299,12 @@ func exec(c *cli.Context) error {
 			Name:  key,
 			Value: val,
 		})
+	}
+
+	drone_env := make(map[string]string)
+	for _, env := range c.StringSlice("env") {
+		envs := strings.Split(env, "=")
+		drone_env[envs[0]] = envs[1]
 	}
 
 	tmpl, err := envsubst.ParseFile(file)
@@ -367,6 +377,7 @@ func exec(c *cli.Context) error {
 		),
 		compiler.WithMetadata(metadata),
 		compiler.WithSecret(secrets...),
+		compiler.WithEnviron(drone_env),
 	).Compile(conf)
 
 	engine, err := docker.NewEnv()

--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -303,7 +303,7 @@ func exec(c *cli.Context) error {
 
 	drone_env := make(map[string]string)
 	for _, env := range c.StringSlice("env") {
-		envs := strings.Split(env, "=")
+		envs := strings.SplitN(env, "=", 2)
 		drone_env[envs[0]] = envs[1]
 	}
 


### PR DESCRIPTION
When running `drone exec` there isn't a way that I have found to specify environment variables when running.  Our current use-case for this is to support specifying an AWS profile when running `drone exec` locally.

# Additional Notes
- This requires the env vars presented to drone to either use `-e`, `--env` (cli flags), or `DRONE_ENV` (environment variable)
- This does **not** pull environment variables that are defined outside of the Drone flags

# Simple Example
`.drone.yml`
```
pipeline:
  printenv:
    image: busybox
    commands:
      - echo $MY_ENV
```

**Negative Testing**
```
-> drone exec
[printenv:L0:0s] + echo $MY_ENV
[printenv:L1:0s]
ruby-2.3.3@all ~/code/tmp/droneexectesting $
-> MY_ENV=test drone exec
[printenv:L0:0s] + echo $MY_ENV
[printenv:L1:0s]
```

**Positive Testing**
```
-> drone exec --env MY_ENV=test
[printenv:L0:0s] + echo $MY_ENV
[printenv:L1:0s] test
ruby-2.3.3@all ~/code/tmp/droneexectesting $
-> drone exec -e MY_ENV=test
[printenv:L0:0s] + echo $MY_ENV
[printenv:L1:0s] test
ruby-2.3.3@all ~/code/tmp/droneexectesting $
-> DRONE_ENV=MY_ENV=test drone exec
[printenv:L0:0s] + echo $MY_ENV
[printenv:L1:0s] test
```

# Practical Example
- When executing terraform locally, use an AWS profile.  When it is pushed to Git, use the IAM permissions associated with the drone server.

Set environment variables:
```
DRONE_VOLUMES=$HOME/.aws/credentials:/root/.aws/credentials
DRONE_ENV=AWS_PROFILE=dev
```

**.drone.yml**
```
pipeline:
  printenv:
    image: hashicorp/terraform
    commands:
      - terraform init
      - terraform plan
```

**test.tf**
```
provider "aws" {
  region = "us-east-1"
}

resource "aws_security_group" "test" {
  name = "test"
}
```

```
-> drone exec
[printenv:L0:0s] + terraform init
...
[printenv:L34:2s]
[printenv:L35:2s] Terraform will perform the following actions:
[printenv:L36:2s]
[printenv:L37:2s]   + aws_security_group.test
[printenv:L38:2s]       id:                     <computed>
[printenv:L39:2s]       description:            "Managed by Terraform"
[printenv:L40:2s]       egress.#:               <computed>
[printenv:L41:2s]       ingress.#:              <computed>
[printenv:L42:2s]       name:                   "test"
[printenv:L43:2s]       owner_id:               <computed>
[printenv:L44:2s]       revoke_rules_on_delete: "false"
[printenv:L45:2s]       vpc_id:                 <computed>
[printenv:L46:2s]
[printenv:L47:2s]
[printenv:L48:2s] Plan: 1 to add, 0 to change, 0 to destroy.
```

