### PR TITLE
Supporting private registries in exec --local

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -275,8 +275,20 @@ var Command = cli.Command{
 			EnvVar: "DRONE_JOB_NUMBER",
 		},
 		cli.StringSliceFlag{
-			Name: "env, e",
+			Name:   "env, e",
 			EnvVar: "DRONE_ENV",
+		},
+		cli.StringFlag{
+			Name:   "registry-host",
+			EnvVar: "DRONE_REGISTRY_HOST",
+		},
+		cli.StringFlag{
+			Name:   "registry-user",
+			EnvVar: "DRONE_REGISTRY_USER",
+		},
+		cli.StringFlag{
+			Name:   "registry-password",
+			EnvVar: "DRONE_REGISTRY_PASSWORD",
 		},
 	},
 }
@@ -350,6 +362,14 @@ func exec(c *cli.Context) error {
 		return lerr
 	}
 
+	var registries []compiler.Registry
+	registries = append(registries, compiler.Registry{
+		Hostname: c.String("registry-host"),
+		Username: c.String("registry-user"),
+		Password: c.String("registry-password"),
+		Email:    "",
+	})
+
 	// compiles the yaml file
 	compiled := compiler.New(
 		compiler.WithEscalated(
@@ -378,6 +398,7 @@ func exec(c *cli.Context) error {
 		compiler.WithMetadata(metadata),
 		compiler.WithSecret(secrets...),
 		compiler.WithEnviron(drone_env),
+		compiler.WithRegistry(registries...),
 	).Compile(conf)
 
 	engine, err := docker.NewEnv()


### PR DESCRIPTION
Running `drone exec --local` fails with authentication errors when using an image for build context that is hosted in a private registry.

You needed to pull the image manually first, but figuring out the exact problem was not straightforward for endusers.

This PR follows the same approach as the Drone server to feed in registries to the Docker backend.

Added 3 new flags to configure the registry when running `drone exec --local`

```
DRONE_REGISTRY_HOST=eu.gcr.io \
DRONE_REGISTRY_USER=oauth2accesstoken \
DRONE_REGISTRY_PASSWORD=$(gcloud auth print-access-token) \
drone exec --local
```