### PR TITLE
Support docker network's CheckDuplicate at drone exec

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,7 +14,7 @@
   version = "v1.0.4"
 
 [[projects]]
-  branch = "master"
+  branch = "feat/support-network-CheckDuplicate"
   name = "github.com/cncd/pipeline"
   packages = [
     "pipeline",
@@ -28,7 +28,8 @@
     "pipeline/interrupt",
     "pipeline/multipart"
   ]
-  revision = "3a09486affc9215ba52f55b1f6e10182458d1aba"
+  revision = "e6ea9bb10018f21225e359f26c2a8f0db0ddec4d"
+  source = "github.com/suzuki-shunsuke/pipeline"
 
 [[projects]]
   name = "github.com/docker/distribution"
@@ -245,6 +246,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3c2492a2f392e0e4d42f2247aca5631e020aed1e2dea238bb56e27739866927a"
+  inputs-digest = "2ee741d53ee4d926367c9fcb25398f4dd060d49911d4391bf50f0614b5faa0b0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,8 @@
 
 [[constraint]]
   name = "github.com/cncd/pipeline"
-  branch = "master"
+  source = "github.com/suzuki-shunsuke/pipeline"
+  branch = "feat/support-network-CheckDuplicate"
 
 [[constraint]]
   name = "github.com/drone/drone-go"

--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -275,7 +275,7 @@ var Command = cli.Command{
 			EnvVar: "DRONE_JOB_NUMBER",
 		},
 		cli.StringSliceFlag{
-			Name: "env, e",
+			Name:   "env, e",
 			EnvVar: "DRONE_ENV",
 		},
 	},
@@ -379,6 +379,13 @@ func exec(c *cli.Context) error {
 		compiler.WithSecret(secrets...),
 		compiler.WithEnviron(drone_env),
 	).Compile(conf)
+	// https://github.com/moby/moby/issues/18864
+	// https://godoc.org/github.com/docker/docker/api/types#NetworkCreate
+	// Set CheckDuplicate to prevent network name collistions.
+	// drone exec executes a local build, so it is natural to make CheckDuplicate true.
+	for _, network := range compiled.Networks {
+		network.CheckDuplicate = true
+	}
 
 	engine, err := docker.NewEnv()
 	if err != nil {

--- a/vendor/github.com/cncd/pipeline/pipeline/backend/backend.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/backend/backend.go
@@ -1,21 +1,24 @@
 package backend
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // Engine defines a container orchestration backend and is used
 // to create and manage container resources.
 type Engine interface {
 	// Setup the pipeline environment.
-	Setup(*Config) error
+	Setup(context.Context, *Config) error
 	// Start the pipeline step.
-	Exec(*Step) error
+	Exec(context.Context, *Step) error
 	// Kill the pipeline step.
-	Kill(*Step) error
+	Kill(context.Context, *Step) error
 	// Wait for the pipeline step to complete and returns
 	// the completion results.
-	Wait(*Step) (*State, error)
+	Wait(context.Context, *Step) (*State, error)
 	// Tail the pipeline step logs.
-	Tail(*Step) (io.ReadCloser, error)
+	Tail(context.Context, *Step) (io.ReadCloser, error)
 	// Destroy the pipeline environment.
-	Destroy(*Config) error
+	Destroy(context.Context, *Config) error
 }

--- a/vendor/github.com/cncd/pipeline/pipeline/backend/docker/convert.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/backend/docker/convert.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
+	"regexp"
 	"strings"
 
 	"github.com/cncd/pipeline/pipeline/backend"
@@ -82,7 +83,10 @@ func toHostConfig(proc *backend.Step) *container.HostConfig {
 			config.Tmpfs[path] = ""
 			continue
 		}
-		parts := strings.Split(path, ":")
+		parts, err := splitVolumeParts(path)
+		if err != nil {
+			continue
+		}
 		config.Tmpfs[parts[0]] = parts[1]
 	}
 	// if proc.OomKillDisable {
@@ -97,7 +101,10 @@ func toHostConfig(proc *backend.Step) *container.HostConfig {
 func toVol(paths []string) map[string]struct{} {
 	set := map[string]struct{}{}
 	for _, path := range paths {
-		parts := strings.Split(path, ":")
+		parts, err := splitVolumeParts(path)
+		if err != nil {
+			continue
+		}
 		if len(parts) < 2 {
 			continue
 		}
@@ -121,9 +128,15 @@ func toEnv(env map[string]string) []string {
 func toDev(paths []string) []container.DeviceMapping {
 	var devices []container.DeviceMapping
 	for _, path := range paths {
-		parts := strings.Split(path, ":")
+		parts, err := splitVolumeParts(path)
+		if err != nil {
+			continue
+		}
 		if len(parts) < 2 {
 			continue
+		}
+		if strings.HasSuffix(parts[1], ":ro") || strings.HasSuffix(parts[1], ":rw") {
+			parts[1] = parts[1][:len(parts[1])-1]
 		}
 		devices = append(devices, container.DeviceMapping{
 			PathOnHost:        parts[0],
@@ -142,4 +155,25 @@ func encodeAuthToBase64(authConfig backend.Auth) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(buf), nil
+}
+
+// helper function that split volume path
+func splitVolumeParts(volumeParts string) ([]string, error) {
+	pattern := `^((?:[\w]\:)?[^\:]*)\:((?:[\w]\:)?[^\:]*)(?:\:([rwom]*))?`
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		return []string{}, err
+	}
+	if r.MatchString(volumeParts) {
+		results := r.FindStringSubmatch(volumeParts)[1:]
+		cleanResults := []string{}
+		for _, item := range results {
+			if item != "" {
+				cleanResults = append(cleanResults, item)
+			}
+		}
+		return cleanResults, nil
+	} else {
+		return strings.Split(volumeParts, ":"), nil
+	}
 }

--- a/vendor/github.com/cncd/pipeline/pipeline/backend/docker/docker.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/backend/docker/docker.go
@@ -35,7 +35,7 @@ func NewEnv() (backend.Engine, error) {
 	return New(cli), nil
 }
 
-func (e *engine) Setup(conf *backend.Config) error {
+func (e *engine) Setup(_ context.Context, conf *backend.Config) error {
 	for _, vol := range conf.Volumes {
 		_, err := e.client.VolumeCreate(noContext, volume.VolumesCreateBody{
 			Name:       vol.Name,
@@ -49,8 +49,9 @@ func (e *engine) Setup(conf *backend.Config) error {
 	}
 	for _, network := range conf.Networks {
 		_, err := e.client.NetworkCreate(noContext, network.Name, types.NetworkCreate{
-			Driver:  network.Driver,
-			Options: network.DriverOpts,
+			Driver:         network.Driver,
+			Options:        network.DriverOpts,
+			CheckDuplicate: network.CheckDuplicate,
 			// Labels:  defaultLabels,
 		})
 		if err != nil {
@@ -60,9 +61,7 @@ func (e *engine) Setup(conf *backend.Config) error {
 	return nil
 }
 
-func (e *engine) Exec(proc *backend.Step) error {
-	ctx := context.Background()
-
+func (e *engine) Exec(ctx context.Context, proc *backend.Step) error {
 	config := toConfig(proc)
 	hostConfig := toHostConfig(proc)
 
@@ -126,12 +125,12 @@ func (e *engine) Exec(proc *backend.Step) error {
 	return e.client.ContainerStart(ctx, proc.Name, startOpts)
 }
 
-func (e *engine) Kill(proc *backend.Step) error {
+func (e *engine) Kill(_ context.Context, proc *backend.Step) error {
 	return e.client.ContainerKill(noContext, proc.Name, "9")
 }
 
-func (e *engine) Wait(proc *backend.Step) (*backend.State, error) {
-	_, err := e.client.ContainerWait(noContext, proc.Name)
+func (e *engine) Wait(ctx context.Context, proc *backend.Step) (*backend.State, error) {
+	_, err := e.client.ContainerWait(ctx, proc.Name)
 	if err != nil {
 		// todo
 	}
@@ -151,8 +150,8 @@ func (e *engine) Wait(proc *backend.Step) (*backend.State, error) {
 	}, nil
 }
 
-func (e *engine) Tail(proc *backend.Step) (io.ReadCloser, error) {
-	logs, err := e.client.ContainerLogs(noContext, proc.Name, logsOpts)
+func (e *engine) Tail(ctx context.Context, proc *backend.Step) (io.ReadCloser, error) {
+	logs, err := e.client.ContainerLogs(ctx, proc.Name, logsOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +166,7 @@ func (e *engine) Tail(proc *backend.Step) (io.ReadCloser, error) {
 	return rc, nil
 }
 
-func (e *engine) Destroy(conf *backend.Config) error {
+func (e *engine) Destroy(_ context.Context, conf *backend.Config) error {
 	for _, stage := range conf.Stages {
 		for _, step := range stage.Steps {
 			e.client.ContainerKill(noContext, step.Name, "9")

--- a/vendor/github.com/cncd/pipeline/pipeline/backend/types.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/backend/types.go
@@ -65,9 +65,10 @@ type (
 
 	// Network defines a container network.
 	Network struct {
-		Name       string            `json:"name,omitempty"`
-		Driver     string            `json:"driver,omitempty"`
-		DriverOpts map[string]string `json:"driver_opts,omitempty"`
+		Name           string            `json:"name,omitempty"`
+		Driver         string            `json:"driver,omitempty"`
+		DriverOpts     map[string]string `json:"driver_opts,omitempty"`
+		CheckDuplicate bool              `json:"check_duplicate,omitempty"`
 	}
 
 	// Volume defines a container volume.

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/metadata.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/metadata.go
@@ -176,7 +176,7 @@ func (m *Metadata) EnvironDrone() map[string]string {
 	params := map[string]string{
 		"CI":                         "drone",
 		"DRONE":                      "true",
-		"DRONE_ARCH":                 "linux/amd64",
+		"DRONE_ARCH":                 m.Sys.Arch,
 		"DRONE_REPO":                 m.Repo.Name,
 		"DRONE_REPO_SCM":             "git",
 		"DRONE_REPO_OWNER":           owner,

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/compiler.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/compiler.go
@@ -75,10 +75,17 @@ func (c *Compiler) Compile(conf *yaml.Config) *backend.Config {
 	})
 
 	// create a default network
-	config.Networks = append(config.Networks, &backend.Network{
-		Name:   fmt.Sprintf("%s_default", c.prefix),
-		Driver: "bridge",
-	})
+	if c.metadata.Sys.Arch == "windows/amd64" {
+		config.Networks = append(config.Networks, &backend.Network{
+			Name:   fmt.Sprintf("%s_default", c.prefix),
+			Driver: "nat",
+		})
+	} else {
+		config.Networks = append(config.Networks, &backend.Network{
+			Name:   fmt.Sprintf("%s_default", c.prefix),
+			Driver: "bridge",
+		})
+	}
 
 	// overrides the default workspace paths when specified
 	// in the YAML file.

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/convert.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/convert.go
@@ -77,12 +77,11 @@ func (c *Compiler) createProcess(name string, container *yaml.Container, section
 
 	if len(container.Commands) != 0 {
 		if c.metadata.Sys.Arch == "windows/amd64" {
-			// TODO provide windows implementation
-			entrypoint = []string{"/bin/sh", "-c"}
-			command = []string{"echo $CI_SCRIPT | base64 -d | /bin/sh -e"}
+			entrypoint = []string{"powershell", "-noprofile", "-noninteractive", "-command"}
+			command = []string{"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Env:CI_SCRIPT)) | iex"}
 			environment["CI_SCRIPT"] = generateScriptWindows(container.Commands)
-			environment["HOME"] = "/root"
-			environment["SHELL"] = "/bin/sh"
+			environment["HOME"] = "c:\\root"
+			environment["SHELL"] = "powershell.exe"
 		} else {
 			entrypoint = []string{"/bin/sh", "-c"}
 			command = []string{"echo $CI_SCRIPT | base64 -d | /bin/sh -e"}

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/script_win.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/script_win.go
@@ -1,5 +1,49 @@
 package compiler
 
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
 func generateScriptWindows(commands []string) string {
-	return ""
+	var buf bytes.Buffer
+	for _, command := range commands {
+		escaped := fmt.Sprintf("%q", command)
+		escaped = strings.Replace(escaped, "$", `\$`, -1)
+		buf.WriteString(fmt.Sprintf(
+			traceScriptWin,
+			escaped,
+			command,
+		))
+	}
+	script := fmt.Sprintf(
+		setupScriptWin,
+		buf.String(),
+	)
+	return base64.StdEncoding.EncodeToString([]byte(script))
 }
+
+const setupScriptWin = `
+$ErrorActionPreference = 'Stop';
+&cmd /c "mkdir c:\root";
+if ($Env:CI_NETRC_MACHINE) {
+$netrc=[string]::Format("{0}\_netrc",$Env:HOME);
+"machine $Env:CI_NETRC_MACHINE" >> $netrc;
+"login $Env:CI_NETRC_USERNAME" >> $netrc;
+"password $Env:CI_NETRC_PASSWORD" >> $netrc;
+};
+[Environment]::SetEnvironmentVariable("CI_NETRC_PASSWORD",$null);
+[Environment]::SetEnvironmentVariable("CI_SCRIPT",$null);
+[Environment]::SetEnvironmentVariable("DRONE_NETRC_USERNAME",$null);
+[Environment]::SetEnvironmentVariable("DRONE_NETRC_PASSWORD",$null);
+%s
+`
+
+// traceScript is a helper script that is added to the build script
+// to trace a command.
+const traceScriptWin = `
+Write-Output ('+ %s');
+& %s; if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
+`

--- a/vendor/github.com/cncd/pipeline/pipeline/pipeline.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/pipeline.go
@@ -55,11 +55,11 @@ func New(spec *backend.Config, opts ...Option) *Runtime {
 // Run starts the runtime and waits for it to complete.
 func (r *Runtime) Run() error {
 	defer func() {
-		r.engine.Destroy(r.spec)
+		r.engine.Destroy(r.ctx, r.spec)
 	}()
 
 	r.started = time.Now().Unix()
-	if err := r.engine.Setup(r.spec); err != nil {
+	if err := r.engine.Setup(r.ctx, r.spec); err != nil {
 		return err
 	}
 
@@ -124,12 +124,12 @@ func (r *Runtime) exec(proc *backend.Step) error {
 		}
 	}
 
-	if err := r.engine.Exec(proc); err != nil {
+	if err := r.engine.Exec(r.ctx, proc); err != nil {
 		return err
 	}
 
 	if r.logger != nil {
-		rc, err := r.engine.Tail(proc)
+		rc, err := r.engine.Tail(r.ctx, proc)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func (r *Runtime) exec(proc *backend.Step) error {
 		return nil
 	}
 
-	wait, err := r.engine.Wait(proc)
+	wait, err := r.engine.Wait(r.ctx, proc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://godoc.org/github.com/docker/docker/api/types#NetworkCreate
https://github.com/moby/moby/issues/18864

Set Docker network's CheckDuplicate option to prevent name's collisions
at drone exec command.
drone exec executes a local build,
so it is natural to make CheckDuplicate true.

Change of Dependencies should be fixed after the following Pull Request has been merged.

https://github.com/cncd/pipeline/pull/44