### PR TITLE
Secret flags

### DIFF
--- a/drone/secret/secret_add.go
+++ b/drone/secret/secret_add.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -10,33 +11,55 @@ import (
 	"github.com/urfave/cli"
 )
 
+var flags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "repository",
+		Usage: "repository name (e.g. octocat/hello-world)",
+	},
+	cli.StringFlag{
+		Name:  "name",
+		Usage: "secret name",
+	},
+	cli.StringFlag{
+		Name:  "value",
+		Usage: "secret value (@path/file.txt to read contents)",
+	},
+	cli.StringSliceFlag{
+		Name:  "image",
+		Usage: "limit to these images (repeat flag for each image)",
+	},
+	cli.BoolFlag{
+		Name:  "push",
+		Usage: "limit to push events",
+	},
+	cli.BoolFlag{
+		Name:  "tag",
+		Usage: "limit to tag events",
+	},
+	cli.BoolFlag{
+		Name:  "deploy",
+		Usage: "limit to deployment events",
+	},
+	cli.BoolFlag{
+		Name:  "pr",
+		Usage: "limit to pull_request events",
+	},
+	cli.BoolFlag{
+		Name:  "all",
+		Usage: "don't limit events",
+	},
+	cli.StringSliceFlag{
+		Name:  "event",
+		Usage: "limit to these events (repeat flag for each event) [deprecated]",
+	},
+}
+
 var secretCreateCmd = cli.Command{
 	Name:      "add",
 	Usage:     "adds a secret",
 	ArgsUsage: "[repo/name]",
 	Action:    secretCreate,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "repository",
-			Usage: "repository name (e.g. octocat/hello-world)",
-		},
-		cli.StringFlag{
-			Name:  "name",
-			Usage: "secret name",
-		},
-		cli.StringFlag{
-			Name:  "value",
-			Usage: "secret value",
-		},
-		cli.StringSliceFlag{
-			Name:  "event",
-			Usage: "secret limited to these events",
-		},
-		cli.StringSliceFlag{
-			Name:  "image",
-			Usage: "secret limited to these images",
-		},
-	},
+	Flags:     flags,
 }
 
 func secretCreate(c *cli.Context) error {
@@ -52,29 +75,67 @@ func secretCreate(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	secret, err := makeSecret(c)
+	if err != nil {
+		return err
+	}
+	if len(secret.Events) == 0 {
+		secret.Events = defaultSecretEvents
+	}
+	_, err = client.SecretCreate(owner, name, secret)
+	if err == nil {
+		return printSecret(secret, tmplSecretList)
+	}
+	return err
+}
+
+func makeSecret(c *cli.Context) (*drone.Secret, error) {
+	events := c.StringSlice("event")
+	for _, e := range events {
+		if !validSecretEvents[e] {
+			return nil, fmt.Errorf("Error: Invalid event (%v).", e)
+		}
+	}
+
+	if c.Bool("push") || c.Bool("all") {
+		events = append(events, drone.EventPush)
+	}
+	if c.Bool("tag") || c.Bool("all") {
+		events = append(events, drone.EventTag)
+	}
+	if c.Bool("deploy") || c.Bool("all") {
+		events = append(events, drone.EventDeploy)
+	}
+	if c.Bool("pr") || c.Bool("all") {
+		events = append(events, drone.EventPull)
+	}
+
 	secret := &drone.Secret{
 		Name:   c.String("name"),
 		Value:  c.String("value"),
 		Images: c.StringSlice("image"),
-		Events: c.StringSlice("event"),
-	}
-	if len(secret.Events) == 0 {
-		secret.Events = defaultSecretEvents
+		Events: events,
 	}
 	if strings.HasPrefix(secret.Value, "@") {
 		path := strings.TrimPrefix(secret.Value, "@")
 		out, ferr := ioutil.ReadFile(path)
 		if ferr != nil {
-			return ferr
+			return nil, ferr
 		}
 		secret.Value = string(out)
 	}
-	_, err = client.SecretCreate(owner, name, secret)
-	return err
+	return secret, nil
 }
 
 var defaultSecretEvents = []string{
 	drone.EventPush,
 	drone.EventTag,
 	drone.EventDeploy,
+}
+
+var validSecretEvents = map[string]bool{
+	drone.EventPush:   true,
+	drone.EventPull:   true,
+	drone.EventTag:    true,
+	drone.EventDeploy: true,
 }

--- a/drone/secret/secret_info.go
+++ b/drone/secret/secret_info.go
@@ -1,9 +1,6 @@
 package secret
 
 import (
-	"html/template"
-	"os"
-
 	"github.com/urfave/cli"
 
 	"github.com/drone/drone-cli/drone/internal"
@@ -53,9 +50,5 @@ func secretInfo(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	tmpl, err := template.New("_").Funcs(secretFuncMap).Parse(format)
-	if err != nil {
-		return err
-	}
-	return tmpl.Execute(os.Stdout, secret)
+	return printSecret(secret, format)
 }

--- a/drone/secret/secret_list.go
+++ b/drone/secret/secret_list.go
@@ -13,6 +13,7 @@ import (
 
 var secretListCmd = cli.Command{
 	Name:      "ls",
+	Aliases:   []string{"list"},
 	Usage:     "list secrets",
 	ArgsUsage: "[repo/name]",
 	Action:    secretList,

--- a/drone/secret/secret_list.go
+++ b/drone/secret/secret_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/drone/drone-cli/drone/internal"
+	"github.com/drone/drone-go/drone"
 )
 
 var secretListCmd = cli.Command{
@@ -49,14 +50,21 @@ func secretList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	for _, secret := range list {
+		err = printSecret(secret, format)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printSecret(secret *drone.Secret, format string) error {
 	tmpl, err := template.New("_").Funcs(secretFuncMap).Parse(format)
 	if err != nil {
 		return err
 	}
-	for _, registry := range list {
-		tmpl.Execute(os.Stdout, registry)
-	}
-	return nil
+	return tmpl.Execute(os.Stdout, secret)
 }
 
 // template for secret list items


### PR DESCRIPTION
Adds these flags the secret add/update command to improve usability and hints:
```
--pr
--deploy
--push
--tag
--all
```

Prints out information about the secret (without the value) after adding or updating the secret.
```
./main secret add octocat/hello-world --name test --value xxx --all
test
Events: push, tag, deployment, pull_request
Images: <any>

./main secret update octocat/hello-world --name test --value xxx --push --pr
test
Events: push, pull_request
Images: <any>
```

Maintains existing behavior (default events, not modifying events on update if no events specified). The only existing known issue is that on update w/o events specified, the returned response has an empty list of events, so it shows empty:
```
./main secret update octocat/hello-world --name test --value xxx
test
Events: 
Images: <any>
```