### PR TITLE
add workaround to support yaml anchors

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -27,6 +27,8 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli"
+
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 var tty = isatty.IsTerminal(os.Stdout.Fd())
@@ -144,6 +146,17 @@ func exec(c *cli.Context) error {
 	}
 
 	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	// workaround to allow yaml anchors
+	var anyJSON map[string]interface{}
+	err = yamlv2.Unmarshal([]byte(data), &anyJSON)
+	if err != nil {
+		return err
+	}
+	data, err = yamlv2.Marshal(anyJSON)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding a workaround to allow yaml anchors to work with drone-cli.  They have been working fine with Drone 0.8.6 server/agents.

This works by unmarshalling from `[]byte` yaml to a `map[string]interface{}` and then back to a `[]byte` yaml.  During this process the anchors are "compiled".  So

```yml
some-anchor: &some-anchor
  image: alpine:3.7
  commands:
    - echo "hello world"

pipeline:
  foo:
    <<: *some-anchor
```

Then becomes:

```yml
pipeline:
  foo:
    commands:
    - echo "hello world"
    image: alpine:3.7

some-anchor:
  commands:
  - echo "hello world"
  image: alpine:3.7
```