### PR TITLE
Updating user command token arg type.

### DIFF
--- a/drone/user/user_add.go
+++ b/drone/user/user_add.go
@@ -23,7 +23,7 @@ var userAddCmd = cli.Command{
 			Name:  "machine",
 			Usage: "machine account",
 		},
-		cli.BoolFlag{
+		cli.StringFlag{
 			Name:  "token",
 			Usage: "api token",
 		},


### PR DESCRIPTION
Setting the flag to `String` type instead of `Bool`