### PR TITLE
Change ocotcat -> octocat in drone exec --repo flag description

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -136,7 +136,7 @@ var Command = cli.Command{
 		},
 		cli.StringFlag{
 			Name:  "repo",
-			Usage: "git repository name (e.g. ocotcat/hello-world)",
+			Usage: "git repository name (e.g. octocat/hello-world)",
 		},
 		cli.StringFlag{
 			Name:  "deploy-to",


### PR DESCRIPTION
Just a little typo I found while experimenting with the exec commend