### PR TITLE
Initial option for setting up ability to sign jsonnet

### DIFF
--- a/drone/jsonnet/jsonnet.go
+++ b/drone/jsonnet/jsonnet.go
@@ -129,7 +129,7 @@ func generate(c *cli.Context) error {
 			return err
 		}
 		jsonnetBuf := new(bytes.Buffer)
-		r, _ := regexp.Compile(`\s*\+\s*\[\s*\{\s*kind\s*:\s*"signature"\s*,.*}\s*\]`)
+		r, _ := regexp.Compile(`\s*\+\s*\[\s*\{\s*kind\s*:\s*"signature"\s*,(.|\s)*}\s*\]`)
 		jsonnetBuf.Write(r.ReplaceAll(data, []byte("")))
 		jsonnetBuf.WriteString(fmt.Sprintf(" + [{kind: \"signature\",hmac: \"%s\"}]\n", hmac))
 		return ioutil.WriteFile(source, jsonnetBuf.Bytes(), 0644)

--- a/drone/jsonnet/jsonnet.go
+++ b/drone/jsonnet/jsonnet.go
@@ -111,6 +111,9 @@ func generate(c *cli.Context) error {
 		pretty.Print(buf, manifest)
 	}
 
+	// the user can optionally sign and write the hmac
+	// generated from the signing process to the jsonnet
+	// file in a way that compiles to yaml as expected
 	if c.Bool("sign") {
 		repo := c.Args().First()
 		owner, name, err := internal.ParseRepo(repo)


### PR DESCRIPTION
So I'm not sure how close this is to working for all the different ways people use Jsonnet to generate drone pipelines, but the idea behind it is that it would be great to be able to not need a .drone.yml file in the repo to push up signed pipelines. This works for the way I setup my .drone.jsonnet files, as a list of pipelines, do you have any opinions around this?
