### PR TITLE
add build create

### DIFF
--- a/drone/build/build.go
+++ b/drone/build/build.go
@@ -16,5 +16,6 @@ var Command = cli.Command{
 		buildDeclineCmd,
 		buildPromoteCmd,
 		buildRollbackCmd,
+		buildCreateCmd,
 	},
 }

--- a/drone/build/build_trigger.go
+++ b/drone/build/build_trigger.go
@@ -1,0 +1,46 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/drone/drone-cli/drone/internal"
+	"github.com/urfave/cli"
+)
+
+var buildCreateCmd = cli.Command{
+	Name:      "create",
+	Usage:     "create a build",
+	ArgsUsage: "<repo/name>",
+	Action:    buildCreate,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "branch, b",
+			Usage: "branch",
+		},
+		cli.StringFlag{
+			Name:  "commit, c",
+			Usage: "commit sha",
+		},
+	},
+}
+
+func buildCreate(c *cli.Context) (err error) {
+	repo := c.Args().First()
+	owner, name, err := internal.ParseRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	client, err := internal.NewClient(c)
+	if err != nil {
+		return err
+	}
+
+	build, err := client.BuildCreate(owner, name, c.String("branch"), c.String("commit"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Created build %s/%s#%d\n", owner, name, build.ID)
+	return nil
+}


### PR DESCRIPTION
Allows CLI users to trigger a build using the following APIs :

``` 
POST /api/repos/{namespace}/{name}/builds
POST /api/repos/{namespace}/{name}/builds?branch={branch}
POST /api/repos/{namespace}/{name}/builds?branch={branch}&commit={commit}
```

This PR is currently stuck, waiting for https://github.com/drone/drone-go/pull/41 to be merged

Tests/builds are expected to fail in the meantime