### PR TITLE
Update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Command line client for the Drone continuous integration server. Please see the official documentation at http://docs.drone.io/cli-installation/
+Command line client for the Drone continuous integration server. Please see the official documentation at https://docs.drone.io/cli/install/


### PR DESCRIPTION
https://docs.drone.io/cli-installation/ is no longer available (404 - Page Not Found)
Changed to https://docs.drone.io/cli/install/