### PR TITLE
Filter server by state

### DIFF
--- a/drone/server/server_list.go
+++ b/drone/server/server_list.go
@@ -20,6 +20,10 @@ var serverListCmd = cli.Command{
 	ArgsUsage: " ",
 	Action:    serverList,
 	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "s, state",
+			Usage: "filter by state",
+		},
 		cli.BoolFlag{
 			Name:  "a, all",
 			Usage: "include stopped servers",
@@ -49,6 +53,7 @@ func serverList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	s := c.String("s")
 	a := c.Bool("a")
 	l := c.Bool("l")
 	h := c.BoolT("H")
@@ -64,7 +69,7 @@ func serverList(c *cli.Context) error {
 	}
 
 	if l && h {
-		printLong(servers, a, h)
+		printLong(servers, s, a, h)
 		return nil
 	}
 
@@ -77,18 +82,26 @@ func serverList(c *cli.Context) error {
 		if !a && server.State == "stopped" {
 			continue
 		}
+
+		if s != "" && s != server.State {
+			continue
+		}
+
 		tmpl.Execute(os.Stdout, server)
 	}
 	return nil
 }
 
-func printLong(servers []*drone.Server, a, h bool) {
+func printLong(servers []*drone.Server, s string, a, h bool) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 	if h {
 		fmt.Fprintln(w, "Name\tAddress\tState\tCreated")
 	}
 	for _, server := range servers {
 		if !a && server.State == "stopped" {
+			continue
+		}
+		if s != "" && s != server.State {
 			continue
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\n",

--- a/drone/server/server_list.go
+++ b/drone/server/server_list.go
@@ -21,15 +21,15 @@ var serverListCmd = cli.Command{
 	Action:    serverList,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
-			Name:  "a",
+			Name:  "a, all",
 			Usage: "include stopped servers",
 		},
 		cli.BoolFlag{
-			Name:  "l",
+			Name:  "l, long",
 			Usage: "list in long format",
 		},
 		cli.BoolTFlag{
-			Name:  "H",
+			Name:  "H, headers",
 			Usage: "include column headers",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
Currently it's pretty annoying to copy and paste the ID of errored agents to delete them immediately. That's why I have added a new option `-s`, or the long form `--state` to filter the server listing by state, e.g. `drone server ls -s error`. That way I can iterate through all errored servers and directly delete them without any hack.

Beside that I have also added long options as an alternative to the short options.