### PR TITLE
add --sha commandline param to drone exec

### DIFF
--- a/drone/exec/env.go
+++ b/drone/exec/env.go
@@ -30,6 +30,10 @@ func getEnv(c *cli.Context) map[string]string {
 		v := c.String("ref")
 		env["DRONE_COMMIT_REF"] = v
 	}
+	if c.IsSet("sha") {
+		v := c.String("sha")
+		env["DRONE_COMMIT_SHA"] = v
+	}
 	if c.IsSet("repo") {
 		v := c.String("repo")
 		env["DRONE_REPO"] = v

--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -137,6 +137,10 @@ var Command = cli.Command{
 			Usage: "git reference",
 		},
 		cli.StringFlag{
+			Name:  "sha",
+			Usage: "git sha",
+		},
+		cli.StringFlag{
 			Name:  "repo",
 			Usage: "git repository name (e.g. octocat/hello-world)",
 		},


### PR DESCRIPTION
So you can test pipelines that use the `DRONE_COMMIT_SHA` env var