### PR TITLE
Add a pipeline type check to the exec command

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/url"
@@ -188,6 +189,11 @@ func exec(c *cli.Context) error {
 		if !ok {
 			continue
 		}
+
+		if v.Type != "" && v.Type != "docker" {
+			return fmt.Errorf("pipeline type (%s) is not supported with 'drone exec'", v.Type)
+		}
+
 		if filter == "" || filter == v.Name {
 			pipeline = v
 			break


### PR DESCRIPTION
If type is not of type 'docker' produce a meaningful
error message. Other pipeline types are not currently
supported by 'drone exec'

The previous error message will likely be
"linter: invalid or missing image", if a
project is using a ssh type, for example.
The error is misleading.

----

example output after this change.

```shell
$ ./release/linux/amd64/drone exec                                                                                                                                                                                                                                                                                                                              
2020/07/14 15:15:00 pipeline type (ssh) is not supported with 'drone exec'
```