### PR TITLE
Add more attributes to local build context

### DIFF
--- a/drone/starlark/starlark.go
+++ b/drone/starlark/starlark.go
@@ -81,6 +81,10 @@ var Command = cli.Command{
 			Value: "master",
 		},
 		cli.StringFlag{
+			Name:  "build.source_repo",
+			Usage: "repo slug of source repository",
+		},
+		cli.StringFlag{
 			Name:  "build.target",
 			Usage: "build target branch",
 			Value: "master",
@@ -97,6 +101,10 @@ var Command = cli.Command{
 		cli.StringFlag{
 			Name:  "build.message",
 			Usage: "build commit message",
+		},
+		cli.StringFlag{
+			Name:  "build.title",
+			Usage: "build title",
 		},
 	},
 }
@@ -137,13 +145,15 @@ func generate(c *cli.Context) error {
 	}
 
 	build := starlark.StringDict{
-		"event":   starlark.String(c.String("build.event")),
-		"branch":  starlark.String(c.String("build.branch")),
-		"source":  starlark.String(c.String("build.source_branch")),
-		"target":  starlark.String(c.String("build.target_branch")),
-		"ref":     starlark.String(c.String("build.ref")),
-		"commit":  starlark.String(c.String("build.commit")),
-		"message": starlark.String(c.String("build.message")),
+		"event":       starlark.String(c.String("build.event")),
+		"branch":      starlark.String(c.String("build.branch")),
+		"source":      starlark.String(c.String("build.source_branch")),
+		"source_repo": starlark.String(c.String("build.source_repo")),
+		"target":      starlark.String(c.String("build.target_branch")),
+		"ref":         starlark.String(c.String("build.ref")),
+		"commit":      starlark.String(c.String("build.commit")),
+		"message":     starlark.String(c.String("build.message")),
+		"title":       starlark.String(c.String("build.title")),
 	}
 
 	args := starlark.Tuple([]starlark.Value{


### PR DESCRIPTION
## Description

When using `drone starlark` locally, some of the context attributes which are available on drone server are missing

## Added

- `build.source_repo`
- `build.title`

```
./drone starlark -h
NAME:
   drone starlark - generate .drone.yml from starlark

USAGE:
   drone starlark [command options] [path/to/.drone.star]

OPTIONS:
   --source value             Source file (default: ".drone.star")
   --target value             target file (default: ".drone.yml")
   --format                   Write output as formatted YAML
   --stdout                   Write output to stdout
   --repo.name value          repository name
   --repo.namespace value     repository namespace
   --repo.slug value          repository slug
   --build.event value        build event (default: "push")
   --build.branch value       build branch (default: "master")
   --build.source value       build source branch (default: "master")
   --build.source_repo value  repo slug of source repository
   --build.target value       build target branch (default: "master")
   --build.ref value          build ref (default: "refs/heads/master")
   --build.commit value       build commit sha
   --build.message value      build commit message
   --build.title value        build title
```