### PR TITLE
feat(cron): add rm command

### DIFF
--- a/drone/cron/cron.go
+++ b/drone/cron/cron.go
@@ -10,6 +10,7 @@ var Command = cli.Command{
 		cronListCmd,
 		cronInfoCmd,
 		cronCreateCmd,
+		cronDeleteCmd,
 		cronDisableCmd,
 		cronEnableCmd,
 	},

--- a/drone/cron/cron_rm.go
+++ b/drone/cron/cron_rm.go
@@ -1,0 +1,28 @@
+package cron
+
+import (
+	"github.com/drone/drone-cli/drone/internal"
+	"github.com/urfave/cli"
+)
+
+var cronDeleteCmd = cli.Command{
+	Name:      "rm",
+	Usage:     "deletes a cronjob",
+	ArgsUsage: "[repo/name] [cronjob]",
+	Action:    cronDelete,
+}
+
+func cronDelete(c *cli.Context) error {
+	slug := c.Args().First()
+	owner, name, err := internal.ParseRepo(slug)
+	if err != nil {
+		return err
+	}
+	client, err := internal.NewClient(c)
+	if err != nil {
+		return err
+	}
+	cron := c.Args().Get(1)
+	client.CronDelete(owner, name, cron)
+	return client.CronDelete(owner, name, cron)
+}


### PR DESCRIPTION
Currently there is support for adding cron schedules through this CLI, but not to delete them. This PR introduces the `drone cron rm` command.