### PR TITLE
(DRON-113) use ghodss/yaml for yaml printing

### DIFF
--- a/drone/format/format.go
+++ b/drone/format/format.go
@@ -6,16 +6,15 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/drone/drone-yaml/yaml"
-	"github.com/drone/drone-yaml/yaml/pretty"
 	"github.com/urfave/cli"
 )
 
 // Command exports the fmt command.
 var Command = cli.Command{
 	Name:      "fmt",
-	Usage:     "format the yaml file",
+	Usage:     "<deprecated. this operation is a no-op> format the yaml file",
 	ArgsUsage: "<source>",
+	Hidden:    true,
 	Action:    format,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
@@ -30,18 +29,11 @@ func format(c *cli.Context) error {
 	if path == "" {
 		path = ".drone.yml"
 	}
-
-	manifest, err := yaml.ParseFile(path)
-	if err != nil {
-		return err
-	}
-
-	buf := new(bytes.Buffer)
-	pretty.Print(buf, manifest)
-
+	out, _ := ioutil.ReadFile(path)
+	buf := bytes.NewBuffer(out)
 	if c.Bool("save") {
 		return ioutil.WriteFile(path, buf.Bytes(), 0644)
 	}
-	_, err = io.Copy(os.Stderr, buf)
+	_, err := io.Copy(os.Stderr, buf)
 	return err
 }

--- a/drone/starlark/starlark.go
+++ b/drone/starlark/starlark.go
@@ -9,9 +9,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/drone/drone-yaml/yaml"
-	"github.com/drone/drone-yaml/yaml/pretty"
-
+	"github.com/ghodss/yaml"
 	"github.com/urfave/cli"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -213,8 +211,7 @@ func generate(c *cli.Context) error {
 		return fmt.Errorf("invalid return type (got a %s)", mainVal.Type())
 	}
 
-	// if the user disables pretty printing, the yaml is printed
-	// to the console or written to the file in json format.
+	// if the user disables pretty printing, the yaml is printed to the console or written to the file in json format.
 	if c.BoolT("format") == false {
 		if c.Bool("stdout") {
 			io.Copy(os.Stdout, buf)
@@ -223,16 +220,14 @@ func generate(c *cli.Context) error {
 		return ioutil.WriteFile(target, buf.Bytes(), 0644)
 	}
 
-	manifest, err := yaml.Parse(buf)
-	if err != nil {
-		return err
+	yml, yErr := yaml.JSONToYAML(buf.Bytes())
+	if yErr != nil {
+		return fmt.Errorf("failed to convert to YAML: %v", yErr)
 	}
 	buf.Reset()
-	pretty.Print(buf, manifest)
+	buf.Write(yml)
 
-	// the user can optionally write the yaml to stdout. This
-	// is useful for debugging purposes without mutating an
-	// existing file.
+	// the user can optionally write the yaml to stdout. This is useful for debugging purposes without mutating an existing file.
 	if c.Bool("stdout") {
 		io.Copy(os.Stdout, buf)
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,11 @@ require (
 	github.com/drone/drone-go v1.6.1
 	github.com/drone/drone-runtime v1.1.1-0.20200623162453-61e33e2cab5d
 	github.com/drone/drone-yaml v0.0.0-20190729072335-70fa398b3560
-	github.com/drone/envsubst v1.0.1
+	github.com/drone/envsubst v1.0.3
 	github.com/drone/funcmap v0.0.0-20190918184546-d4ef6e88376d
 	github.com/drone/signal v1.0.0
 	github.com/fatih/color v1.9.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-jsonnet v0.16.0
 	github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/drone/drone-runtime v1.1.1-0.20200623162453-61e33e2cab5d h1:P5HI/Y9hA
 github.com/drone/drone-runtime v1.1.1-0.20200623162453-61e33e2cab5d/go.mod h1:4/2QToW5+HGD0y1sTw7X35W1f7YINS14UfDY4isggT8=
 github.com/drone/drone-yaml v0.0.0-20190729072335-70fa398b3560 h1:3QL4NnDpGtaXpgI9eNd6N2k5WK8W388CzD67ZTuuZQg=
 github.com/drone/drone-yaml v0.0.0-20190729072335-70fa398b3560/go.mod h1:rCLISp/rqZ50s6G4nKsm971tRSzolxzqqXfgjDqPYoE=
-github.com/drone/envsubst v1.0.1 h1:NOOStingM2sbBwsIUeQkKUz8ShwCUzmqMxWrpXItfPE=
-github.com/drone/envsubst v1.0.1/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
+github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
+github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/drone/funcmap v0.0.0-20190918184546-d4ef6e88376d h1:/IO7UVVu191Jc0DajV4cDVoO+91cuppvgxg2MZl+AXI=
 github.com/drone/funcmap v0.0.0-20190918184546-d4ef6e88376d/go.mod h1:Hph0/pT6ZxbujnE1Z6/08p5I0XXuOsppqF6NQlGOK0E=
 github.com/drone/signal v1.0.0 h1:NrnM2M/4yAuU/tXs6RP1a1ZfxnaHwYkd0kJurA1p6uI=


### PR DESCRIPTION
```
➜  drone-cli git:(drone-113) ✗ release/linux/amd64/drone jsonnet --source=bla.jsonnet  --format --stdout=true
kind: pipeline
name: default
platform:
  arch: amd64
  os: linux
  prune: false
steps:
- image: alpine:latest
  name: test
  pull: always
  settings:
    config: policy.yml
    project: test-dev
    prune: false
    set_env_vars:
      prune: false
```
and stream with multi-part documents with stream
```
release/linux/amd64/drone jsonnet --source=multi.jsonnet --stream --format --stdout=true
---
kind: pipeline
name: go-1-11
steps:
- commands:
  - go get
  - go test
  image: golang:1.11
  name: test
---
kind: pipeline
name: go-1-12
steps:
- commands:
  - go get
  - go test
  image: golang:1.12
  name: test
```
And starlark
```
➜  drone-cli git:(drone-113) ✗ release/linux/amd64/drone starlark --source=bla.star  --format --stdout=true
kind: pipeline
name: build
steps:
- commands:
  - echo hello world
  image: alpine
  name: build
```