### PR TITLE
Increase step limit for starlark

### DIFF
--- a/drone/starlark/starlark.go
+++ b/drone/starlark/starlark.go
@@ -50,7 +50,7 @@ var Command = cli.Command{
 		cli.Uint64Flag{
 			Name:  "max-execution-steps",
 			Usage: "maximum number of execution steps",
-			Value: 50000,
+			Value: 100000,
 		},
 		//
 		// Drone Parameters


### PR DESCRIPTION
- What is the reason for this change

The limit of 50000 steps processed in a run of starlark is too low.

- Example usage of the failure for a bug, or configuration and expected output for a feature
```
$ git clone https://github.com/owncloud/web
$ cd web
$ drone --version
drone version 1.3.3
$ drone starlark
2021/09/02 08:25:16 starlark evaluation error:
Traceback (most recent call last):
  .drone.star:714:28: in main
  .drone.star:751:37: in stagePipelines
  .drone.star:1223:47: in acceptance
  .drone.star:2289:27: in stopBuild
Error: Starlark computation cancelled: too many steps
```


- Steps to test the change

Do `drone starlark` with the increased step limit and see that it runs without the "too many steps" error.

I don't see where this limit has an existing test case. What happens about automated testing?

Also see matching PR https://github.com/drone/drone/pull/3134

(sadly this hard-coded number appears in 2 places)
