### PR TITLE
fixes issue where template info command wasn't working

### DIFF
--- a/drone/template/template_info.go
+++ b/drone/template/template_info.go
@@ -61,6 +61,6 @@ func templateInfo(c *cli.Context) error {
 	return tmpl.Execute(os.Stdout, templates)
 }
 
-var tmplTemplateInfoList = "\x1b[33m{{ .Name }} \x1b[0m" + "\x1b [33m{{ .Namespace }} \x1b[0m" + `
+var tmplTemplateInfoList = "\x1b[33m{{ .Name }} \x1b[0m" + `
 Data:  {{ .Data }}
 `


### PR DESCRIPTION
An issue where the command was looking for namespace which didn't exist. We already filter by namespace.